### PR TITLE
Add syntax-highlighted code editor with CodeMirror

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,9 @@
 // Bootstrap CSSはCDNから読み込むため、ここではカスタムスタイルのみ
 
+// CodeMirror CSS (imported from CDN)
+@import url("https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.css");
+@import url("https://cdn.jsdelivr.net/npm/codemirror@5.65.16/addon/fold/foldgutter.css");
+
 // ナビゲーションバーのカスタマイズ
 .navbar {
   width: 100%; // 親要素の幅に合わせる
@@ -113,6 +117,41 @@ main {
   @media (min-height: 1200px) {
     min-height: 400px !important;
     max-height: calc(100vh - 600px) !important;
+  }
+}
+
+// CodeMirror custom styles to match Bootstrap theme
+.CodeMirror {
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+  font-size: 14px;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', monospace;
+  background-color: #ffffff;
+  
+  &.CodeMirror-focused {
+    border-color: #007bff;
+    box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+  }
+  
+  .CodeMirror-gutters {
+    background-color: #f8f9fa;
+    border-right: 1px solid #dee2e6;
+  }
+  
+  .CodeMirror-linenumber {
+    color: #6c757d;
+  }
+  
+  .CodeMirror-cursor {
+    border-left-color: #007bff;
+  }
+  
+  .CodeMirror-selected {
+    background: rgba(0, 123, 255, 0.1);
+  }
+  
+  .CodeMirror-activeline-background {
+    background: rgba(0, 123, 255, 0.05);
   }
 }
 

--- a/app/javascript/controllers/code_editor_controller.js
+++ b/app/javascript/controllers/code_editor_controller.js
@@ -1,0 +1,82 @@
+import { Controller } from "@hotwired/stimulus"
+import CodeMirror from "codemirror"
+import "codemirror/mode/markdown/markdown"
+import "codemirror/mode/javascript/javascript"
+import "codemirror/mode/xml/xml"
+import "codemirror/mode/css/css"
+
+export default class extends Controller {
+  static targets = ["textarea"]
+
+  connect() {
+    this.initializeEditor()
+  }
+
+  disconnect() {
+    if (this.editor) {
+      this.editor.toTextArea()
+    }
+  }
+
+  initializeEditor() {
+    const textarea = this.textareaTarget
+    
+    this.editor = CodeMirror.fromTextArea(textarea, {
+      mode: "markdown",
+      theme: "default",
+      lineNumbers: true,
+      lineWrapping: true,
+      indentUnit: 2,
+      tabSize: 2,
+      autoCloseBrackets: true,
+      matchBrackets: true,
+      showCursorWhenSelecting: true,
+      styleActiveLine: true,
+      foldGutter: true,
+      gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
+      extraKeys: {
+        "Ctrl-Space": "autocomplete",
+        "Tab": function(cm) {
+          if (cm.somethingSelected()) {
+            cm.indentSelection("add");
+          } else {
+            cm.replaceSelection("  ");
+          }
+        }
+      }
+    })
+
+    // Sync editor content with textarea for form submission
+    this.editor.on("change", () => {
+      textarea.value = this.editor.getValue()
+      // Trigger change event for any other listeners
+      textarea.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    // Set initial height
+    this.editor.setSize(null, "400px")
+    
+    // Focus the editor when clicked
+    this.editor.on("focus", () => {
+      this.editor.refresh()
+    })
+  }
+
+  // Method to insert text at cursor position (for image/video insertion)
+  insertText(text) {
+    if (this.editor) {
+      const doc = this.editor.getDoc()
+      const cursor = doc.getCursor()
+      doc.replaceRange(text, cursor)
+      this.editor.focus()
+    }
+  }
+
+  // Method to get current cursor position for external usage
+  getCursorPosition() {
+    if (this.editor) {
+      return this.editor.getDoc().getCursor()
+    }
+    return null
+  }
+}

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -268,8 +268,11 @@
                 <% end %>
               </small>
             <% end %>
-            <%= form.text_area :content, class: "form-control flex-grow-1 #{'is-invalid' if post.errors[:content].any?}",
-                               id: "contentTextarea", required: true, style: "overflow:auto; resize:none;", placeholder: "内容を入力してください" %>
+            <div data-controller="code-editor">
+              <%= form.text_area :content, class: "form-control flex-grow-1 #{'is-invalid' if post.errors[:content].any?}",
+                                 id: "contentTextarea", required: true, style: "overflow:auto; resize:none;", 
+                                 placeholder: "内容を入力してください", data: { "code-editor-target" => "textarea" } %>
+            </div>
             <div class="invalid-feedback">
               内容を入力してください。
             </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,3 +8,10 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 
 # Passkey module
 pin "passkey"
+
+# CodeMirror for syntax highlighting
+pin "codemirror", to: "https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.js"
+pin "codemirror/mode/markdown/markdown", to: "https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/markdown/markdown.js"
+pin "codemirror/mode/javascript/javascript", to: "https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/javascript/javascript.js"
+pin "codemirror/mode/xml/xml", to: "https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/xml/xml.js"
+pin "codemirror/mode/css/css", to: "https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/css/css.js"


### PR DESCRIPTION
- Integrate CodeMirror 5.65.16 via importmap for syntax highlighting
- Create Stimulus controller for code editor functionality
- Add CodeMirror CSS styling to match Bootstrap theme
- Update posts form to use syntax-highlighted editor for content field
- Support for markdown, JavaScript, XML, and CSS syntax highlighting
- Responsive design with proper focus and validation states