### PR TITLE
fix: モバイル版でフッターの固定位置を解除

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -309,6 +309,11 @@ main {
 
   // モバイル端末でのフッター調整
   footer {
+    // ★★★ 追加: モバイルではfixedを解除 ★★★
+    position: static !important;
+    box-shadow: none;
+    z-index: auto;
+    
     // フッターの内部パディングを縮小
     .container-fluid {
       padding-left: 1rem;
@@ -330,15 +335,20 @@ main {
     }
   }
   
-  // メインコンテンツの下部余白を縮小
+  // メインコンテンツの下部余白を削除（固定フッターが無いため）
   main {
-    padding-bottom: calc(80px + env(safe-area-inset-bottom)); // 120px → 80px
+    padding-bottom: 1rem; // 80px → 1rem
   }
 }
 
 @media (max-width: 480px) {
   // さらに小さなモバイル端末での調整
   footer {
+    // ★★★ 追加: より小さな画面でもfixedを解除 ★★★
+    position: static !important;
+    box-shadow: none;
+    z-index: auto;
+    
     .container-fluid {
       padding-left: 0.5rem;
       padding-right: 0.5rem;
@@ -357,8 +367,9 @@ main {
     }
   }
   
+  // メインコンテンツの下部余白を削除
   main {
-    padding-bottom: calc(70px + env(safe-area-inset-bottom)); // さらに縮小
+    padding-bottom: 0.5rem; // さらに縮小
   }
 }
 


### PR DESCRIPTION
- モバイル端末(768px以下)でフッターをposition: staticに変更
- 固定フッター用のbox-shadowとz-indexを削除
- メインコンテンツの下部余白を大幅に縮小(固定フッターが不要のため)
- 480px以下の小さな画面でも同様の調整を適用